### PR TITLE
fix: align matches header size with other pages

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -30,7 +30,7 @@ const TabsLayout = () => {
                 }}
             />
             <Tabs.Screen
-                name="matches/index"
+                name="matches"
                 options={{
                     headerShown: false,
                     headerTitle: "Match History",

--- a/app/(tabs)/matches/_layout.tsx
+++ b/app/(tabs)/matches/_layout.tsx
@@ -13,23 +13,23 @@ const StackLayout = () => {
         headerTintColor: Colors.dark.text,
         headerTitleStyle: {
           color: Colors.dark.text,
-          fontSize: 16,
-          fontWeight: "600",
+          fontSize: 20,
+          fontWeight: "bold",
         },
       }}
     >
       <Stack.Screen
         name="index"
         options={{
-          headerTitle: "",
-          headerShown: false
+          headerTitle: "MATCHES",
+          headerShown: true,
         }}
       />
       <Stack.Screen
         name="[matchId]"
         options={{
-          headerTitle: "",
-          headerShown: false,
+          headerTitle: "MATCH DETAILS",
+          headerShown: true,
         }}
       />
     </Stack>


### PR DESCRIPTION
## Summary
- fix matches tab routing in tabs layout to use the nested folder route name so tab behavior is consistent
- align Matches stack header typography with other pages by using explicit bold title styling and a larger title size
- ensure both Matches list and Match Details screens show proper headers with consistent visual hierarchy

## Verification
- run `npx tsc --noEmit`
- open Matches tab and verify header title size matches other tab screens
- open a Match Details screen and verify header styling remains consistent