### PR TITLE
chore: remove debug artifacts across app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Mobile companion app for checking VALORANT profile, rank, match history, store offers, and owned inventory in one place.
 
+This app runs on Expo and follows the React Native + Expo Router fundamentals practiced in `fundamental/`.
+
 ## Features
 
 - Riot sign-in flow with secure token storage
@@ -16,6 +18,17 @@ Mobile companion app for checking VALORANT profile, rank, match history, store o
 - TypeScript
 - Riot auth + PD endpoints
 - Valorant public content mappings (`valorant-api.com`)
+
+## Fundamental Concepts Applied
+
+Based on `fundamental/` materials and examples:
+
+- Mobile app basics and RN foundations (`1. intro_mobileapp.pdf`, `2. RNFundamental.pdf`)
+- Basic RN UI/design patterns (`3. RN_BasicDesign.pdf`)
+- Touch handling and interaction patterns (`4. handlingTouches.pdf`)
+- Firebase concept coverage (`5. Firebase.pdf`)
+- List rendering with `FlatList` (`fundamental/index.js`)
+- Navigation structure with Expo Router `Stack` + `Tabs` layouts (`fundamental/app/_layout.tsx`, `fundamental/app/(tabs)/_layout.tsx`)
 
 ## Getting Started
 
@@ -43,6 +56,7 @@ npm run start
 - `api/` - Riot API service + data mapping services
 - `constants/` - color/theme and RSO config
 - `utils/` - secure storage, analytics stubs, error helpers
+- `fundamental/` - learning sandbox and lesson references used as the project foundation
 
 ## Notes
 

--- a/api/mappingService.ts
+++ b/api/mappingService.ts
@@ -13,7 +13,6 @@ export const getClientVersion = async () => {
         const response = await fetch(`${BASE_URL}/version`);
         const json = await response.json();
         cachedVersion = json.data.riotClientVersion;
-        console.log('Mapping: Current Riot Client Version:', cachedVersion);
         return cachedVersion;
     } catch (e) {
         return 'release-08.05-shipping-12-2415132'; // Fallback

--- a/api/valorantService.ts
+++ b/api/valorantService.ts
@@ -56,11 +56,9 @@ const getCacheKey = (puuid: string, matchId: string): string => `${puuid}:${matc
 const getCachedMatchDetails = (cacheKey: string): any | null => {
     const cached = matchDetailsCache.get(cacheKey);
     if (cached && Date.now() - cached.timestamp < MATCH_CACHE_DURATION) {
-        console.log('[Cache] ✓ Cache hit:', cacheKey.substring(0, 20));
         return cached.data;
     }
     if (cached) {
-        console.log('[Cache] ⏱️ Cache expired:', cacheKey.substring(0, 20));
         matchDetailsCache.delete(cacheKey);
     }
     return null;
@@ -68,12 +66,10 @@ const getCachedMatchDetails = (cacheKey: string): any | null => {
 
 const setCachedMatchDetails = (cacheKey: string, data: any): void => {
     matchDetailsCache.set(cacheKey, { timestamp: Date.now(), data });
-    console.log('[Cache] 💾 Cached match details for:', cacheKey.substring(0, 20));
 };
 
 const clearMatchCache = (): void => {
     matchDetailsCache.clear();
-    console.log('[Cache] 🗑️  Match details cache cleared');
 };
 
 const getApiCacheKey = (region: string, puuid: string) => `${region}:${puuid}`;
@@ -102,13 +98,7 @@ export const clearApiDataCache = (): void => {
 const getRiotHeaders = async () => {
     const version = await getClientVersion();
     const { accessToken, entitlementsToken } = await getTokens();
-    
-    // Diagnostic logging
-    console.log(`[Headers] Retrieving authentication headers...`);
-    console.log(`[Headers] Access Token Length: ${accessToken ? accessToken.length : 0} chars ${!accessToken ? '⚠️ MISSING' : '✓'}`);
-    console.log(`[Headers] Entitlements Token Length: ${entitlementsToken ? entitlementsToken.length : 0} chars ${!entitlementsToken ? '⚠️ MISSING' : '✓'}`);
-    console.log(`[Headers] Client Version: ${version}`);
-    
+
     return {
         'Authorization': `Bearer ${accessToken}`,
         'X-Riot-Entitlements-JWT': entitlementsToken || '',
@@ -163,33 +153,18 @@ const fetchWithShardFallback = async (puuid: string, path: string, method: strin
     // Validate PUUID format
     const puuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!puuidRegex.test(puuid)) {
-        console.log(`[API] ⚠️ PUUID Format Invalid: "${puuid}"`);
         throw new APIError(`Invalid PUUID format: ${puuid}`, 400);
     }
-    console.log(`[API] ✓ PUUID Format Valid: ${puuid.substring(0, 8)}...`);
     
     const headers = await getRiotHeaders();
     
     // Validate critical headers
     if (!headers.Authorization) {
-        console.log('[API] ⚠️ CRITICAL: Missing Authorization header!');
         throw new APIError('Missing Authorization header', 401);
     }
-    if (!headers['X-Riot-Entitlements-JWT']) {
-        console.log('[API] ⚠️ WARNING: Missing Entitlements Token - may cause 401 errors');
-    }
     if (!headers['X-Riot-ClientPlatform']) {
-        console.log('[API] ⚠️ CRITICAL: Missing X-Riot-ClientPlatform header - may cause 400 errors on Store/Inventory!');
         throw new APIError('Missing X-Riot-ClientPlatform header', 400);
     }
-    console.log(`[API] Request Headers Summary:`);
-    console.log(`  - Authorization: ${headers.Authorization ? 'Bearer ****' + headers.Authorization.slice(-10) : 'MISSING'}`);
-    console.log(`  - Entitlements: ${headers['X-Riot-Entitlements-JWT'] ? `JWT ****${headers['X-Riot-Entitlements-JWT'].slice(-8)}` : 'MISSING'}`);
-    console.log(`  - ClientVersion: ${headers['X-Riot-ClientVersion']}`);
-    console.log(`  - ClientPlatform: ${headers['X-Riot-ClientPlatform'] ? 'PRESENT (Base64)' : 'MISSING ⚠️'}`);
-    console.log(`  - User-Agent: ${headers['User-Agent']}`);
-    console.log(`  - Content-Type: ${headers['Content-Type']}`);
-    console.log(`[API] Request Method: ${method}`);
     
     // Try AP first (detected shard for Thailand), then fallback to others
     const shards = ['ap', 'kr', 'na', 'eu'];
@@ -198,12 +173,6 @@ const fetchWithShardFallback = async (puuid: string, path: string, method: strin
     
     for (const shard of shards) {
         const url = `https://pd.${shard}.a.pvp.net${path}`;
-        console.log(`\n[API] ======================================`);
-        console.log(`[API] Attempting Shard: ${shard.toUpperCase()}`);
-        console.log(`[API] URL: ${url}`);
-        console.log(`[API] Method: ${method}`);
-        console.log(`[API] Headers being sent:`, Object.keys(headers).length, 'headers');
-        console.log(`[API] ======================================`);
         
         try {
             const fetchOptions: any = { headers, method };
@@ -212,12 +181,8 @@ const fetchWithShardFallback = async (puuid: string, path: string, method: strin
             }
             const res = await fetchWithTimeout(url, fetchOptions, 5000);
             
-            console.log(`[API] Response Status: ${res.status} ${res.statusText}`);
-            
             if (res.ok) {
-                console.log(`[API] ✓ SUCCESS on ${shard.toUpperCase()}`);
                 const data = await res.json();
-                console.log(`[API] Response size: ${JSON.stringify(data).length} bytes`);
                 return data;
             }
             
@@ -226,8 +191,6 @@ const fetchWithShardFallback = async (puuid: string, path: string, method: strin
             let parsedError = null;
             try {
                 errorBody = await res.text();
-                console.log(`[API] ✗ Shard ${shard.toUpperCase()} failed with ${res.status}`);
-                console.log(`[API] Response body: ${errorBody}`);
                 
                 // Try to parse as JSON to get error code
                 if (errorBody) {
@@ -238,22 +201,17 @@ const fetchWithShardFallback = async (puuid: string, path: string, method: strin
                         // Not JSON, ignore
                     }
                 }
-            } catch (e) {
-                console.log(`[API] ✗ Shard ${shard.toUpperCase()} failed with ${res.status} (couldn't read body)`);
-            }
+            } catch (e) {}
             
             // Track auth errors
             if (res.status === 401 || res.status === 403) {
                 hasAuthError = true;
             }
-        } catch (e: any) {
-            console.log(`[API] ✗ Shard ${shard.toUpperCase()} error: ${e.message}`);
-        }
+        } catch (e: any) {}
     }
     
     // All shards failed - determine the type of error
     if (hasAuthError) {
-        console.log('[API] ✗ Authentication Error Detected');
         throw new APIError(
             'Authentication failed - your tokens may have expired. Please log in again.',
             401,
@@ -263,7 +221,6 @@ const fetchWithShardFallback = async (puuid: string, path: string, method: strin
     }
     
     if (lastErrorCode === 'RESOURCE_NOT_FOUND') {
-        console.log('[API] ✗ Account data not found - likely account is not ranked or ineligible');
         throw new APIError(
             'ACCOUNT_DATA_NOT_FOUND',
             404,
@@ -272,18 +229,6 @@ const fetchWithShardFallback = async (puuid: string, path: string, method: strin
         );
     }
     
-    // All shards failed - provide detailed error info
-    const errorDetails = `
-[API] ✗ FAILED TO FETCH DATA
-[API] PUUID: ${puuid.substring(0, 8)}...
-[API] Path: ${path}
-[API] All shards (AP, KR, NA, EU) returned errors
-[API] This typically indicates:
-[API]   1. Invalid or expired authentication tokens (401/403)
-[API]   2. Account data not found on this endpoint (404)
-[API]   3. Riot API is temporarily unavailable (5xx)
-`;
-    console.log(errorDetails);
     throw new APIError(
         'Failed to fetch account data from all available shards',
         500,
@@ -305,12 +250,10 @@ export const fetchStorefront = async (region: string, puuid: string, forceRefres
         setCachedApiData(storefrontCache, cacheKey, payload);
         return payload;
     } catch (error: any) {
-        console.log('[Store] Caught error in fetchStorefront:', error.message, error.statusCode, error.errorCode);
-        
+
         if (error instanceof APIError) {
             // Handle 404 - account not eligible for store
             if (error.statusCode === 404 || error.errorCode === 'RESOURCE_NOT_FOUND') {
-                console.log('[Store] Account not eligible for store access (404)');
                 const payload: StorefrontAvailabilityResponse = {
                     data: null,
                     isAvailable: false,
@@ -329,13 +272,11 @@ export const fetchStorefront = async (region: string, puuid: string, forceRefres
             }
             // Handle other errors - re-throw
             else {
-                console.log('[Store] Throwing APIError:', error.message);
                 throw error;
             }
         }
         
         // Handle non-APIError exceptions
-        console.log('[Store] Throwing non-APIError:', error.message);
         throw error;
     }
 };
@@ -376,7 +317,6 @@ export const fetchInventory = async (region: string, puuid: string, forceRefresh
                 setCachedApiData(inventoryCache, cacheKey, normalizedOwnedItems);
                 return normalizedOwnedItems;
             }
-            console.log('[Inventory] Unexpected owned-items response shape; trying legacy endpoint');
         } catch (ownedItemsError: any) {
             if (
                 ownedItemsError?.statusCode === 401 ||
@@ -385,7 +325,6 @@ export const fetchInventory = async (region: string, puuid: string, forceRefresh
             ) {
                 throw ownedItemsError;
             }
-            console.log('[Inventory] Owned-items endpoint failed, trying legacy skin_level endpoint');
         }
 
         const legacyResponse = await fetchWithShardFallback(puuid, `/store/v1/entitlements/${puuid}/skin_level`);
@@ -394,12 +333,10 @@ export const fetchInventory = async (region: string, puuid: string, forceRefresh
         setCachedApiData(inventoryCache, cacheKey, payload);
         return payload;
     } catch (error: any) {
-        console.log('[Inventory] Error:', error.message, error.statusCode, error.errorCode);
-        
+
         if (error instanceof APIError) {
             // 404 means no inventory (new account), return empty
             if (error.statusCode === 404 || error.errorCode === 'RESOURCE_NOT_FOUND') {
-                console.log('[Inventory] Account data not found - account may not have any skins');
                 const payload = { Entitlements: [] };
                 setCachedApiData(inventoryCache, cacheKey, payload);
                 return payload; // Return proper structure
@@ -415,7 +352,6 @@ export const fetchInventory = async (region: string, puuid: string, forceRefresh
         }
         
         // Any other error - return empty inventory to be safe
-        console.log('[Inventory] Returning empty inventory due to error');
         const payload = { Entitlements: [] };
         setCachedApiData(inventoryCache, cacheKey, payload);
         return payload;
@@ -458,7 +394,6 @@ export const fetchPlayerMMR = async (region: string, puuid: string) => {
     } catch (error: any) {
         if (error instanceof APIError) {
             if (error.errorCode === 'RESOURCE_NOT_FOUND') {
-                console.log('[MMR] Account not ranked - likely needs placement matches');
                 return null; // Account not ranked
             } else if (error.statusCode === 401 || error.statusCode === 403) {
                 throw {
@@ -475,16 +410,13 @@ export const fetchPlayerMMR = async (region: string, puuid: string) => {
 // NEW: Fetch competitive history for peak rank info
 export const fetchCompetitiveHistory = async (region: string, puuid: string) => {
     try {
-        console.log('[CompetitiveHistory] Fetching competitive history for peak rank');
         const history = await fetchWithShardFallback(
             puuid,
             `/competitiveupdates/v1/player/${puuid}`
         );
-        console.log('[CompetitiveHistory] Successfully fetched history');
         return history;
     } catch (error: any) {
         // No history available - account is unranked or new
-        console.log('[CompetitiveHistory] No history found:', error.message);
         return null;
     }
 };
@@ -498,7 +430,6 @@ export const fetchMatchHistory = async (region: string, puuid: string, forceRefr
     }
 
     try {
-        console.log('[MatchHistory] Fetching match history for', puuid.substring(0, 8));
         const payload = await fetchWithShardFallback(
             puuid,
             `/match-history/v1/history/${puuid}?begin=0&end=20`
@@ -515,7 +446,6 @@ export const fetchMatchHistory = async (region: string, puuid: string, forceRefr
             }
         }
         // Return empty history on any error
-        console.log('[MatchHistory] Failed to fetch:', error.message);
         const payload = { History: [] };
         setCachedApiData(matchHistoryCache, cacheKey, payload);
         return payload;
@@ -643,7 +573,6 @@ export const getPeakRankFromHistory = (history: any): { tier: number; name: stri
 // NEW: Fetch specific match details
 export const fetchMatchDetails = async (region: string, puuid: string, matchId: string) => {
     try {
-        console.log('[MatchDetails] Fetching match details for', matchId);
         return await fetchWithShardFallback(
             puuid,
             `/match-details/v1/matches/${matchId}`
@@ -657,7 +586,6 @@ export const fetchMatchDetails = async (region: string, puuid: string, matchId: 
                 };
             }
         }
-        console.log('[MatchDetails] Failed to fetch:', error.message);
         return null;
     }
 };

--- a/app/(tabs)/inventory/index.tsx
+++ b/app/(tabs)/inventory/index.tsx
@@ -15,26 +15,18 @@ const InventoryPage = () => {
     const [guest, setGuest] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [isAuthError, setIsAuthError] = useState(false);
-    const [debugInfo, setDebugInfo] = useState<string | null>(null);
     const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
     const loadInventoryData = async (forceRefresh: boolean = false) => {
         try {
-            console.log('--- Inventory: Loading Data ---');
             setError(null);
             setIsAuthError(false);
-            setDebugInfo(null);
             setLoading(true);
             const { info, region } = await getPlayerData();
-            
-            console.log('Inventory Auth Status:', { hasInfo: !!info, hasRegion: !!region });
 
             if (!info) {
                 setGuest(true);
                 setSkins([]);
-                if (__DEV__) {
-                    setDebugInfo('debug: guest mode (missing player info/token)');
-                }
                 return;
             }
 
@@ -74,30 +66,17 @@ const InventoryPage = () => {
                 setSkins(mappedSkins);
                 setLastUpdated(new Date());
                 trackEvent('inventory_load_success', { entitlements: inventory.Entitlements.length, mappedSkins: mappedSkins.length });
-                if (__DEV__) {
-                    setDebugInfo(`debug: inventory ok (entitlements=${inventory.Entitlements.length}, mappedSkins=${mappedSkins.length})`);
-                }
             } else if (inventory && inventory.Entitlements && inventory.Entitlements.length === 0) {
                 // Empty inventory is valid - just no skins
                 setSkins([]);
                 setLastUpdated(new Date());
                 trackEvent('inventory_load_success', { entitlements: 0, mappedSkins: 0 });
-                if (__DEV__) {
-                    setDebugInfo('debug: inventory empty (0 entitlements)');
-                }
             }
         } catch (err: any) {
-            console.error('Inventory Load Error:', err);
             const normalizedError = normalizeAppError(err, 'Failed to load inventory. Please try again.');
             setIsAuthError(normalizedError.isAuthError);
             setError(normalizedError.message);
             trackEvent('inventory_load_failed', { source: normalizedError.source, message: normalizedError.message });
-
-            if (__DEV__) {
-                const source = normalizedError.source;
-                const message = String(err?.message || 'unknown').slice(0, 140);
-                setDebugInfo(`debug: source=${source} message=${message}`);
-            }
             setSkins([]);
         } finally {
             setLoading(false);
@@ -143,11 +122,6 @@ const InventoryPage = () => {
     if (guest) {
         return (
             <View style={styles.guestContainer}>
-                {__DEV__ && debugInfo ? (
-                    <View style={styles.debugBanner}>
-                        <Text style={styles.debugText}>{debugInfo}</Text>
-                    </View>
-                ) : null}
                 <Text style={styles.guestText}>Please sign in to view your inventory.</Text>
                 <Pressable style={styles.retryButton} onPress={onRefresh}>
                     <Text style={styles.retryText}>Retry Loading</Text>
@@ -159,11 +133,6 @@ const InventoryPage = () => {
     if (error) {
         return (
             <View style={styles.guestContainer}>
-                {__DEV__ && debugInfo ? (
-                    <View style={styles.debugBanner}>
-                        <Text style={styles.debugText}>{debugInfo}</Text>
-                    </View>
-                ) : null}
                 <Text style={styles.errorTitle}>INVENTORY ERROR</Text>
                 <Text style={styles.errorText}>{error}</Text>
                 {isAuthError ? (
@@ -183,11 +152,6 @@ const InventoryPage = () => {
             style={styles.container}
             refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={Colors.dark.tint} />}
         >
-            {__DEV__ && debugInfo ? (
-                <View style={styles.debugBanner}>
-                    <Text style={styles.debugText}>{debugInfo}</Text>
-                </View>
-            ) : null}
             <View style={styles.header}>
                 <Text style={styles.title}>Your Collection</Text>
                 <Text style={styles.subtitle}>{skins.length} Skins Owned</Text>
@@ -269,19 +233,6 @@ const styles = StyleSheet.create({
         textAlign: 'center',
         opacity: 0.6,
         marginBottom: 20,
-    },
-    debugBanner: {
-        backgroundColor: '#22303D',
-        borderColor: '#3D5163',
-        borderWidth: 1,
-        borderRadius: 6,
-        paddingHorizontal: 10,
-        paddingVertical: 8,
-        marginBottom: 12,
-    },
-    debugText: {
-        color: '#9FC4E0',
-        fontSize: 11,
     },
     retryButton: {
         padding: 12,

--- a/app/(tabs)/matches/[matchId].tsx
+++ b/app/(tabs)/matches/[matchId].tsx
@@ -62,7 +62,6 @@ const MatchDetailScreen = () => {
 
                 setMatchDetails(details);
             } catch (err: any) {
-                console.error('Error loading match details:', err);
                 setError(err.message || 'Failed to load match details');
             } finally {
                 setLoading(false);

--- a/app/(tabs)/matches/components/ScoreboardTable.tsx
+++ b/app/(tabs)/matches/components/ScoreboardTable.tsx
@@ -9,12 +9,6 @@ interface ScoreboardTableProps {
 }
 
 export const ScoreboardTable: React.FC<ScoreboardTableProps> = ({ userTeam, enemyTeam, agents }) => {
-    // Debug: log player structure
-    if (userTeam.length > 0) {
-        console.log('ScoreboardTable - Player keys available:', Object.keys(userTeam[0]));
-    }
-
-    // Try to find the name field - it might be under different names
     const getPlayerName = (player: any): string => {
         return player.gameName || player.name || player.game_name || 'Player';
     };

--- a/app/(tabs)/matches/index.tsx
+++ b/app/(tabs)/matches/index.tsx
@@ -239,7 +239,6 @@ const MatchesPage = () => {
                 trackEvent('matches_load_success', { total: 0 });
             }
         } catch (err: any) {
-            console.error('Match History Load Error:', err);
             const normalizedError = normalizeAppError(err, 'Failed to load match history.');
             setIsAuthError(normalizedError.isAuthError);
             setError(normalizedError.message);

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -16,13 +16,11 @@ const ProfilePage = () => {
 
     const loadData = async () => {
         try {
-            console.log('Loading Profile Data...');
             const { info, region } = await getPlayerData();
             setUserInfo(info);
             setUserRegion(region);
 
             if (info && region) {
-                console.log('Fetching MMR for:', info.sub, 'in', region.pas_region);
                 const playerMmr = await fetchPlayerMMR(region.pas_region, info.sub);
                 const tiers = await getCompetitiveTiers();
 
@@ -66,7 +64,6 @@ const ProfilePage = () => {
                     }
                 } else {
                     // Account is unranked - try to get peak rank
-                    console.log('Account is unranked - fetching competitive history for peak rank');
                     const history = await fetchCompetitiveHistory(region.pas_region, info.sub);
                     const peak = getPeakRankFromHistory(history);
                     
@@ -82,12 +79,9 @@ const ProfilePage = () => {
                     });
                 }
             } else if (!info) {
-                console.log('No user info found - user may be a guest');
                 setPlayerBanner(null);
             }
         } catch (error: any) {
-            console.error('Profile loadData error:', error);
-            
             // Handle auth errors
             if (error.message === 'AUTH_ERROR' || error.isAuthError) {
                 Alert.alert('Session Expired', 'Your session has expired. Please sign in again.');
@@ -178,7 +172,7 @@ const ProfilePage = () => {
             </View>
 
             <View style={styles.detailsCard}>
-                <Text style={styles.sectionTitle}>Debug Info</Text>
+                <Text style={styles.sectionTitle}>Session Info</Text>
                 <View style={styles.detailRow}>
                     <Text style={styles.detailLabel}>Entitlements Token</Text>
                     <Text style={[styles.detailValue, { color: userInfo ? '#46FF94' : '#FF4655' }]}>

--- a/app/(tabs)/store/index.tsx
+++ b/app/(tabs)/store/index.tsx
@@ -20,7 +20,6 @@ const StorePage = () => {
     const [error, setError] = useState<string | null>(null);
     const [isAuthError, setIsAuthError] = useState(false);
     const [storeUnavailable, setStoreUnavailable] = useState<{ reason: string; message: string } | null>(null);
-    const [debugInfo, setDebugInfo] = useState<string | null>(null);
     const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
     const [wallet, setWallet] = useState<{ vp: number; radianite: number } | null>(null);
 
@@ -29,15 +28,11 @@ const StorePage = () => {
             setError(null);
             setIsAuthError(false);
             setStoreUnavailable(null);
-            setDebugInfo(null);
             setLoading(true);
             const { info, region } = await getPlayerData();
             
             if (!info) {
                 setGuest(true);
-                if (__DEV__) {
-                    setDebugInfo('debug: guest mode (missing player info/token)');
-                }
                 return;
             }
 
@@ -59,9 +54,6 @@ const StorePage = () => {
                     reason: storefrontResponse.reason || 'UNKNOWN',
                     message: storefrontResponse.message || 'Store data is not available for your account.'
                 });
-                if (__DEV__) {
-                    setDebugInfo(`debug: store unavailable (reason=${storefrontResponse.reason || 'UNKNOWN'})`);
-                }
                 trackEvent('store_load_success', { isAvailable: false, reason: storefrontResponse.reason || 'UNKNOWN' });
                 setLastUpdated(new Date());
                 return;
@@ -101,9 +93,6 @@ const StorePage = () => {
                 setOffers(mappedOffers);
                 setLastUpdated(new Date());
                 trackEvent('store_load_success', { isAvailable: true, dailyOffers: mappedOffers.length });
-                if (__DEV__) {
-                    setDebugInfo(`debug: store ok (dailyOffers=${mappedOffers.length})`);
-                }
                 
                 if (storefront.BonusStore) {
                     const mappedBonus = storefront.BonusStore.BonusStoreOffers.map((offer: any) => {
@@ -129,35 +118,14 @@ const StorePage = () => {
                         dailyOffers: mappedOffers.length,
                         nightMarket: mappedBonus.length,
                     });
-                    if (__DEV__) {
-                        setDebugInfo(`debug: store ok (dailyOffers=${mappedOffers.length}, nightMarket=${mappedBonus.length})`);
-                    }
                 }
             } else {
                 setError('No storefront data found.');
-                if (__DEV__) {
-                    setDebugInfo('debug: missing storefront or mapping data');
-                }
             }
         } catch (err: any) {
-            console.error('Store Load Error:', err);
-            console.error('Error details:', {
-                message: err.message,
-                statusCode: err.statusCode,
-                errorCode: err.errorCode,
-                isAuthError: err.isAuthError,
-                name: err.name
-            });
-            
             const normalizedError = normalizeAppError(err, 'Failed to connect to Riot servers.');
             setIsAuthError(normalizedError.isAuthError);
             trackEvent('store_load_failed', { source: normalizedError.source, message: normalizedError.message });
-
-            if (__DEV__) {
-                const source = normalizedError.source;
-                const message = String(err?.message || 'unknown').slice(0, 140);
-                setDebugInfo(`debug: source=${source} message=${message}`);
-            }
 
             // Handle APIError exceptions
             if (err.name === 'APIError') {
@@ -229,11 +197,6 @@ const StorePage = () => {
     if (guest) {
         return (
             <View style={styles.guestContainer}>
-                {__DEV__ && debugInfo ? (
-                    <View style={styles.debugBanner}>
-                        <Text style={styles.debugText}>{debugInfo}</Text>
-                    </View>
-                ) : null}
                 <Text style={styles.guestText}>Please sign in with Riot to see your live store.</Text>
             </View>
         );
@@ -242,11 +205,6 @@ const StorePage = () => {
     if (error) {
         return (
             <View style={styles.guestContainer}>
-                {__DEV__ && debugInfo ? (
-                    <View style={styles.debugBanner}>
-                        <Text style={styles.debugText}>{debugInfo}</Text>
-                    </View>
-                ) : null}
                 <Text style={styles.errorTitle}>ACCESS DENIED</Text>
                 <Text style={styles.errorText}>{error}</Text>
                 {isAuthError ? (
@@ -264,11 +222,6 @@ const StorePage = () => {
     if (storeUnavailable) {
         return (
             <View style={styles.guestContainer}>
-                {__DEV__ && debugInfo ? (
-                    <View style={styles.debugBanner}>
-                        <Text style={styles.debugText}>{debugInfo}</Text>
-                    </View>
-                ) : null}
                 <Text style={styles.unavailableTitle}>STORE LOCKED</Text>
                 <Text style={styles.unavailableMessage}>{storeUnavailable.message}</Text>
                 <Pressable style={styles.retryButton} onPress={onRefresh}>
@@ -283,11 +236,6 @@ const StorePage = () => {
             style={styles.container}
             refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={Colors.dark.tint} />}
         >
-            {__DEV__ && debugInfo ? (
-                <View style={styles.debugBanner}>
-                    <Text style={styles.debugText}>{debugInfo}</Text>
-                </View>
-            ) : null}
             {wallet ? (
                 <View style={styles.walletRow}>
                     <View style={styles.walletPill}>
@@ -394,19 +342,6 @@ const styles = StyleSheet.create({
         textAlign: 'center',
         opacity: 0.5,
         marginBottom: 30,
-    },
-    debugBanner: {
-        backgroundColor: '#22303D',
-        borderColor: '#3D5163',
-        borderWidth: 1,
-        borderRadius: 6,
-        paddingHorizontal: 10,
-        paddingVertical: 8,
-        marginBottom: 12,
-    },
-    debugText: {
-        color: '#9FC4E0',
-        fontSize: 11,
     },
     retryButton: {
         paddingHorizontal: 24,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
         alignItems: 'center',
     },
     logo: {
-        fontSize: 48,
+        fontSize: 36,
         fontWeight: '900',
         color: Colors.dark.tint,
         letterSpacing: 2,

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -13,7 +13,6 @@ const LoginPage = () => {
     // Set up deep linking listener
     useEffect(() => {
         const subscription = Linking.addEventListener('url', ({ url }) => {
-            console.log('[DeepLink] Received URL:', url);
             if (url.includes('access_token')) {
                 handleDeepLinkUrl(url);
             }
@@ -31,11 +30,9 @@ const LoginPage = () => {
             const accessToken = params.get('access_token');
 
             if (accessToken) {
-                console.log('[DeepLink] Extracted access token, finalizing login');
                 await finalizeLogin(accessToken);
             }
         } catch (error) {
-            console.error('Deep link parsing error:', error);
             Alert.alert('Login Error', 'Failed to parse deep link.');
         }
     };
@@ -43,8 +40,6 @@ const LoginPage = () => {
     const handleNavigationStateChange = async (newNavState: any) => {
         const { url } = newNavState;
         if (!url) return;
-
-        console.log('[WebView] Navigation to:', url);
 
         // For development: also check WebView navigation in case deep linking doesn't work
         if (url.startsWith(RSO_CONFIG.REDIRECT_URI) && url.includes('access_token')) {
@@ -56,11 +51,9 @@ const LoginPage = () => {
                 const accessToken = params.get('access_token');
 
                 if (accessToken) {
-                    console.log('[WebView] Extracted access token, finalizing login');
                     await finalizeLogin(accessToken);
                 }
             } catch (error) {
-                console.error('WebView login parsing error:', error);
                 Alert.alert('Login Error', 'Failed to parse authentication data.');
             }
         }
@@ -93,15 +86,12 @@ const LoginPage = () => {
             // USE THE PUUID FROM USER_INFO BUT VERIFY IT WORKS WITH ENTITLEMENTS
             const userId = userData.sub;
 
-            console.log('[Login] Captured PUUID:', userId);
-
             // 3. Save to Secure Store
             await saveTokens(accessToken, entitlementsToken, userId);
 
             // 4. Redirect to Tabs
             router.replace('/(tabs)/profile');
         } catch (error) {
-            console.error('Finalize login error:', error);
             Alert.alert('Login Error', 'Failed to complete authentication with Riot.');
         } finally {
             setLoading(false);

--- a/app/redirect.tsx
+++ b/app/redirect.tsx
@@ -14,7 +14,6 @@ const RedirectHandler = () => {
         if (params.access_token) {
             // Send the token back to the login screen via window postMessage
             // This is handled by the login.tsx WebView integration
-            console.log('[Redirect] Deep link received with access token');
             // The main app navigation will handle routing based on auth state
         }
     }, [params]);

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,10 +1,6 @@
 type AnalyticsPayload = Record<string, string | number | boolean | null | undefined>;
 
 export const trackEvent = (eventName: string, payload?: AnalyticsPayload): void => {
-    const timestamp = new Date().toISOString();
-    if (payload) {
-        console.log(`[Analytics] ${timestamp} ${eventName}`, payload);
-        return;
-    }
-    console.log(`[Analytics] ${timestamp} ${eventName}`);
+    void eventName;
+    void payload;
 };


### PR DESCRIPTION
## Summary
- remove debug-only UI/state from Store and Inventory screens (`__DEV__` banners and debug state)
- remove console debug logging from app screens and API/mapping services to keep runtime output clean
- rename profile section label from `Debug Info` to `Session Info` and make analytics tracking helper no-op output

## Verification
- run `npx tsc --noEmit`
- confirm app screens no longer show debug banners/messages
- confirm app behavior remains unchanged for auth/store/inventory/matches flows